### PR TITLE
Remove AnyView requirement for root view and destinations view builder

### DIFF
--- a/Sources/InfiniteNavigation/Helper/View+Environments.swift
+++ b/Sources/InfiniteNavigation/Helper/View+Environments.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 extension View {
-    func apply(environments: Environments) -> AnyView {
+    func apply(environments: [Environment]) -> AnyView {
         var result: any View = self
         environments.forEach { result = (result.environmentObject($0) as any View) }
         return result.toAnyView()

--- a/Sources/InfiniteNavigation/InfiniteNavContainer.swift
+++ b/Sources/InfiniteNavigation/InfiniteNavContainer.swift
@@ -5,7 +5,7 @@ import Combine
 internal struct Sheet: Identifiable {
     let id = UUID().uuidString
     var path = NavigationPath()
-    let source: () -> AnyView
+    let source: () -> any View
 }
 
 public typealias Environments = [any ObservableObject]
@@ -14,7 +14,7 @@ public typealias Environments = [any ObservableObject]
 public struct InfiniteNavContainer<Destination: Hashable, Root: View>: View {
 
     public typealias NavDestinationPublisher = AnyPublisher<NavAction<Destination>, Never>
-    public typealias NavDestinationBuilder = (Destination) -> AnyView
+    public typealias NavDestinationBuilder = (Destination) -> any View
     
     private let navAction: NavDestinationPublisher
     private let viewBuilder: NavDestinationBuilder
@@ -83,7 +83,7 @@ extension InfiniteNavContainer {
         .toAnyView()
     }
     
-    private func wrap(_ view: some View) -> some View {
+    private func wrap(_ view: any View) -> some View {
         view
             .apply(environments: environments)
             .navigationBarHidden(true)

--- a/Sources/InfiniteNavigation/InfiniteNavContainer.swift
+++ b/Sources/InfiniteNavigation/InfiniteNavContainer.swift
@@ -8,7 +8,7 @@ internal struct Sheet: Identifiable {
     let source: () -> any View
 }
 
-public typealias Environments = [any ObservableObject]
+public typealias Environment = any ObservableObject
 
 @available(iOS 16.0, *)
 public struct InfiniteNavContainer<Destination: Hashable, Root: View>: View {
@@ -18,14 +18,14 @@ public struct InfiniteNavContainer<Destination: Hashable, Root: View>: View {
     
     private let navAction: NavDestinationPublisher
     private let viewBuilder: NavDestinationBuilder
-    private let environments: Environments
+    private let environments: [Environment]
     
     @State private var stack: [Sheet]
     
     init(
         initialStack: [Destination] = [],
         navAction: NavDestinationPublisher,
-        environments: Environments = [],
+        environments: [Environment] = [],
         viewBuilder: @escaping NavDestinationBuilder,
         root: @escaping () -> Root
     ) {

--- a/Sources/InfiniteNavigation/InfiniteNavigation.swift
+++ b/Sources/InfiniteNavigation/InfiniteNavigation.swift
@@ -8,7 +8,7 @@ public struct InfiniteNavigation {
         initialStack: [Destination] = [],
         navAction: AnyPublisher<NavAction<Destination>, Never>,
         environments: any ObservableObject...,
-        viewBuilder: @escaping (Destination) -> AnyView,
+        viewBuilder: @escaping (Destination) -> some View,
         @ViewBuilder root: @escaping () -> Root
     ) -> some View {
         create(
@@ -25,7 +25,7 @@ public struct InfiniteNavigation {
         initialStack: [Destination] = [],
         navAction: AnyPublisher<NavAction<Destination>, Never>,
         environments: Environments = [],
-        viewBuilder: @escaping (Destination) -> AnyView,
+        viewBuilder: @escaping (Destination) -> some View,
         @ViewBuilder root: @escaping () -> Root
     ) -> some View {
         if #available(iOS 16.0, *) {

--- a/Sources/InfiniteNavigation/InfiniteNavigation.swift
+++ b/Sources/InfiniteNavigation/InfiniteNavigation.swift
@@ -9,7 +9,7 @@ public struct InfiniteNavigation {
         navAction: AnyPublisher<NavAction<Destination>, Never>,
         environments: any ObservableObject...,
         viewBuilder: @escaping (Destination) -> AnyView,
-        root: @escaping () -> Root
+        @ViewBuilder root: @escaping () -> Root
     ) -> some View {
         create(
             initialStack: initialStack,
@@ -26,7 +26,7 @@ public struct InfiniteNavigation {
         navAction: AnyPublisher<NavAction<Destination>, Never>,
         environments: Environments = [],
         viewBuilder: @escaping (Destination) -> AnyView,
-        root: @escaping () -> Root
+        @ViewBuilder root: @escaping () -> Root
     ) -> some View {
         if #available(iOS 16.0, *) {
             InfiniteNavContainer(

--- a/Sources/InfiniteNavigation/InfiniteNavigation.swift
+++ b/Sources/InfiniteNavigation/InfiniteNavigation.swift
@@ -7,7 +7,7 @@ public struct InfiniteNavigation {
     public static func create<Root: View, Destination: Hashable>(
         initialStack: [Destination] = [],
         navAction: AnyPublisher<NavAction<Destination>, Never>,
-        environments: any ObservableObject...,
+        environments: Environment...,
         viewBuilder: @escaping (Destination) -> some View,
         @ViewBuilder root: @escaping () -> Root
     ) -> some View {
@@ -24,7 +24,7 @@ public struct InfiniteNavigation {
     public static func create<Root: View, Destination: Hashable>(
         initialStack: [Destination] = [],
         navAction: AnyPublisher<NavAction<Destination>, Never>,
-        environments: Environments = [],
+        environments: [Environment] = [],
         viewBuilder: @escaping (Destination) -> some View,
         @ViewBuilder root: @escaping () -> Root
     ) -> some View {

--- a/Sources/InfiniteNavigation/LegacyInfiniteNavContainer.swift
+++ b/Sources/InfiniteNavigation/LegacyInfiniteNavContainer.swift
@@ -6,7 +6,7 @@ public struct LegacyInfiniteNavContainer<Root: SwiftUI.View, View>: UIViewContro
     
     public typealias UIViewControllerType = UINavigationController
     public typealias NavDestinationPublisher = AnyPublisher<NavAction<View>, Never>
-    public typealias NavDestinationBuilder = (View) -> AnyView
+    public typealias NavDestinationBuilder = (View) -> any SwiftUI.View
     
     private let coordinator: Coordinator
     private let rootResolver: () -> Root

--- a/Sources/InfiniteNavigation/LegacyInfiniteNavContainer.swift
+++ b/Sources/InfiniteNavigation/LegacyInfiniteNavContainer.swift
@@ -17,7 +17,7 @@ public struct LegacyInfiniteNavContainer<Root: SwiftUI.View, View>: UIViewContro
     internal init(
         initialStack: [View] = [],
         navAction: NavDestinationPublisher,
-        environments: Environments = [],
+        environments: [Environment] = [],
         viewBuilder: @escaping NavDestinationBuilder,
         root: @escaping () -> Root
     ) {
@@ -50,11 +50,11 @@ public struct LegacyInfiniteNavContainer<Root: SwiftUI.View, View>: UIViewContro
         
         var resolver: Resolver?
         
-        private let environments: Environments
+        private let environments: [Environment]
         private let viewBuilder: NavDestinationBuilder
         private var navSubscription: AnyCancellable?
         
-        init(navAction: NavDestinationPublisher, environments: Environments, viewBuilder: @escaping NavDestinationBuilder) {
+        init(navAction: NavDestinationPublisher, environments: [Environment], viewBuilder: @escaping NavDestinationBuilder) {
             self.environments = environments
             self.viewBuilder = viewBuilder
             


### PR DESCRIPTION
Previously the `InfiniteNavigation` container required the `viewBuilder` completion to return `AnyView`, now any function that returns `some View` can be used, e.g.

```swift
InfiniteNavigation.create(
    navAction: navigation.publisher,
    viewBuilder: buildDestination(_:)
    ...

@ViewBuilder
func build(_ destination: MyDestination) -> some View {
    switch destination {
    case .home: HomeView()
    ...
```

Furthermore the `rootView` completion is annotated with `@ViewBuilder`, providing more flexibility, e.g. conditional root views.